### PR TITLE
Allow to specify encoding for every input/output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 **srtmerge** is a Python library used to merge two Srt files.
 
 ## Usage
-```python
-    from srtmerge import srtmerge
-    srtmerge([filepath1, filepath2, ...], out_filepath, offset=1000)
+```
+from srtmerge import srtmerge
+srtmerge({'filepath1':'enconding', 'filepath2':None, ...}, out_filepath, offset=1000)
 ```
 
-`srtmerge filepath1 filepath2 out_filepath offset=1000`
+`srtmerge filepath1:encoding1 filepath2 filepath3:encoding3 out_filepath offset=1000`

--- a/srtmerge/cli.py
+++ b/srtmerge/cli.py
@@ -20,6 +20,8 @@ __author__ = 'wistful'
 __version__ = '1.0'
 __release_date__ = "15/01/2014"
 
+FILE_ENCODING_SEPARATOR = ":"
+
 import os
 import sys
 
@@ -42,7 +44,8 @@ def _check_argv(args):
     if len(inPaths) < 2:
         print_error("too few arguments")
         return False
-    for path in inPaths:
+    for path_entry in inPaths:
+        path = path_entry.split(FILE_ENCODING_SEPARATOR)[0]
         if not os.path.exists(path):
             print_error("file {srt_file} does not exist".format(srt_file=path))
             return False
@@ -53,7 +56,7 @@ def main():
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('inPath', type=str, nargs='+',
-                        help='srt-files that should be merged. Optionally you can specify the enconding appending it with colon, like this: srt1 srt2:ascii srt3:latin-1')
+                        help='srt-files that should be merged. Optionally you can specify the enconding appending it with colon, like this: srt1 srt2{separator}ascii srt3{separator}latin-1'.format(separator=FILE_ENCODING_SEPARATOR))
     parser.add_argument('outPath', type=str,
                         help='output file path')
     parser.add_argument('--offset', action='store_const', const=0, default=0,
@@ -71,7 +74,7 @@ def main():
     args = vars(parser.parse_args())
     if _check_argv(args):
         in_srts = {
-            in_srt.split(":")[0] : in_srt.split(":")[1] if len(in_srt.split(":"))>1 else None
+            in_srt.split(FILE_ENCODING_SEPARATOR)[0] : in_srt.split(FILE_ENCODING_SEPARATOR)[1] if len(in_srt.split(FILE_ENCODING_SEPARATOR))>1 else None
             for in_srt in args.get('inPath','')
         }
         srtmerge(in_srts,

--- a/srtmerge/cli.py
+++ b/srtmerge/cli.py
@@ -53,7 +53,7 @@ def main():
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('inPath', type=str, nargs='+',
-                        help='srt-files that should be merged')
+                        help='srt-files that should be merged. Optionally you can specify the enconding appending it with colon, like this: srt1 srt2:ascii srt3:latin-1')
     parser.add_argument('outPath', type=str,
                         help='output file path')
     parser.add_argument('--offset', action='store_const', const=0, default=0,
@@ -70,7 +70,11 @@ def main():
         sys.exit(0)
     args = vars(parser.parse_args())
     if _check_argv(args):
-        srtmerge(args.get('inPath'),
+        in_srts = {
+            in_srt.split(":")[0] : in_srt.split(":")[1] if len(in_srt.split(":"))>1 else None
+            for in_srt in args.get('inPath','')
+        }
+        srtmerge(in_srts,
                  args.get('outPath'),
                  args.get('offset'),
                  not args.get('nochardet'),

--- a/srtmerge/srt.py
+++ b/srtmerge/srt.py
@@ -174,7 +174,6 @@ def srtmerge(in_srt_files, out_srt,
         }
     for file_path,_encoding in in_srt_files.iteritems():
         in_encoding = _encoding or (detect_encoding(file_path) if use_chardet else encoding)
-        print file_path,in_encoding
         subs = subs + subreader(file_path, encoding=in_encoding)
 
     subwriter(out_srt, subs, offset, encoding)

--- a/srtmerge/srt.py
+++ b/srtmerge/srt.py
@@ -30,7 +30,8 @@ from chardet.universaldetector import UniversalDetector
 
 SubRecord = namedtuple('SubRecord', ['start', 'finish', 'text'])
 DEFAULT_ENCODING = 'utf-8'
-
+#needed to know args format
+ACCEPT_SRT_ENCODING = True
 
 class Subtitles(Sequence, Iterable):
 
@@ -165,8 +166,15 @@ def detect_encoding(file_path):
 def srtmerge(in_srt_files, out_srt,
              offset=0, use_chardet=False, encoding=DEFAULT_ENCODING):
     subs = Subtitles()
-    for file_path in in_srt_files:
-        in_encoding = detect_encoding(file_path) if use_chardet else DEFAULT_ENCODING
+    #RETROCOMPATIBILITY: allow old style args
+    if type(in_srt_files) == type([]):
+        in_srt_files = {
+            srt : detect_encoding(srt) if use_chardet else encoding
+            for srt in in_srt_files
+        }
+    for file_path,_encoding in in_srt_files.iteritems():
+        in_encoding = _encoding or (detect_encoding(file_path) if use_chardet else encoding)
+        print file_path,in_encoding
         subs = subs + subreader(file_path, encoding=in_encoding)
 
     subwriter(out_srt, subs, offset, encoding)


### PR DESCRIPTION
Hi again, I've stripped out color stuff but I've fixed the input-enconding issue.

I've solved as you proposed, with arguments like file:enconding. Here some successful samples:

```
#command line sample 1
xecgr@carteras:~/dev$ srtmerge Game.Of.Thrones.S01.E03.2011.1080p.BluRay.x264.DTS-HDChina.srt Game.of.Thrones.S01E03.HDTV.XviD-FQM.es.srt:CP1252 "S01E03.Lord Snow.srt"
xecgr@carteras:~/dev$ head -n 6 S01E03.Lord\ Snow.srt 
1
00:00:06,000 --> 00:00:12,074
Shop this shows fashion, download the
"LookLive" app in iTunes
Anuncie su producto o marca aquí        # encoding OK
contáctenos www.OpenSubtitles.org hoy   # encoding OK
```
```
#command line sample 2
xecgr@carteras:~/dev$ srtmerge  Game.Of.Thrones.S01.E03.2011.1080p.BluRay.x264.DTS-HDChina.srt Game.of.Thrones.S01E03.HDTV.XviD-FQM.es.srt "S01E03.Lord Snow.chardet.srt"
xecgr@carteras:~/dev$ head -n 6 S01E03.Lord\ Snow.chardet.srt 
1
00:00:06,000 --> 00:00:12,074
Shop this shows fashion, download the
"LookLive" app in iTunes
Anuncie su producto o marca aquн        #it was encoded using chardet, it detects windows-1251
contбctenos www.OpenSubtitles.org hoy   #it was encoded using chardet, it detects windows-1251
```
```
#script sample 1
from srtmerge import srtmerge
srts = {
    "Game.Of.Thrones.S01.E03.2011.1080p.BluRay.x264.DTS-HDChina.srt" : None,
    "Game.of.Thrones.S01E03.HDTV.XviD-FQM.es.srt"                    : "CP1252" 
}
out_filepath = "S01E03.Lord Snow.script.srt"
srtmerge(srts, out_filepath, offset=1)
xecgr@carteras:~/dev$ head -n 6 S01E03.Lord\ Snow.srt 
1
00:00:06,000 --> 00:00:12,074
Shop this shows fashion, download the
"LookLive" app in iTunes
Anuncie su producto o marca aquí        # encoding OK
contáctenos www.OpenSubtitles.org hoy   # encoding OK
```

```
#script sample 2
from srtmerge import srtmerge
srts = [
    "Game.Of.Thrones.S01.E03.2011.1080p.BluRay.x264.DTS-HDChina.srt",
    "Game.of.Thrones.S01E03.HDTV.XviD-FQM.es.srt"                   , 
]
out_filepath = "S01E03.Lord Snow.retro.srt"
srtmerge(srts, out_filepath, offset=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/srtmerge/srt.py", line 177, in srtmerge
    subs = subs + subreader(file_path, encoding=in_encoding)
  File "/usr/local/lib/python2.7/dist-packages/srtmerge/srt.py", line 196, in subreader
    line = line.decode(encoding).strip()
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xed in position 31: invalid continuation byte
#root cause of issue opening
```

```
#script sample 3 (allow retrocompability)
from srtmerge import srtmerge
srts = [
    "Game.Of.Thrones.S01.E03.2011.1080p.BluRay.x264.DTS-HDChina.srt",
    "Game.of.Thrones.S01E03.HDTV.XviD-FQM.es.srt"                   , 
]
out_filepath = "S01E03.Lord Snow.retro.srt"
srtmerge(srts, out_filepath, offset=1,use_chardet=True)
xecgr@carteras:~/dev$ head -n 6 S01E03.Lord\ Snow.retro.srt 
1
00:00:06,000 --> 00:00:12,074
Shop this shows fashion, download the
"LookLive" app in iTunes
Anuncie su producto o marca aquн        #it was encoded using chardet, it detects windows-1251
contбctenos www.OpenSubtitles.org hoy   #it was encoded using chardet, it detects windows-1251
```
For output file it's fine utf-8, because we set encoding and we work with unicodes, so let's use a easy one